### PR TITLE
Fix use of uninitialized memory

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -x
+
+libtoolize --force
+aclocal
+autoheader
+automake --add-missing
+autoconf

--- a/src/ela_libevent.c
+++ b/src/ela_libevent.c
@@ -186,9 +186,9 @@ ela_error_t _ela_source_alloc(
 
     src->priv = priv;
     src->handler = func;
-    event_base_set(ctx->event, &src->event);
     src->flags = 0;
     event_set(&src->event, -1, EV_PERSIST, _ela_event_cb, src);
+    event_base_set(ctx->event, &src->event);
 
     *source = src;
     return 0;


### PR DESCRIPTION
When using `libevent` libela fails to initialize `event` structures on event source allocation. This PR eliminates this problem.
